### PR TITLE
update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,8 +9,8 @@
 
     <license>Apache 2.0</license>
     <keywords>microsoft, azure, adal, activedirectory</keywords>
-    <repo>https://github.com/AzureAD/azure-activedirectory-library-for-cordova</repo>
-    <issue>https://github.com/AzureAD/azure-activedirectory-library-for-cordova/issues</issue>
+    <repo>https://github.com/mlynch/azure-activedirectory-library-for-cordova</repo>
+    <issue>https://github.com/mlynch/azure-activedirectory-library-for-cordova/issues</issue>
 
     <dependency id="cordova-plugin-compat" version="^1.0.0" />
 


### PR DESCRIPTION
Hey @mlynch. Thanks for the forked repo!  I thought this update may help fix below error.  I get the below error running cordova plugin add https://github.com/mlynch/azure-activedirectory-library-for-cordova.git. I've also tried the --nofetch flag and adding from the unzipped src, but that is not working either. Any ideas?

CordovaError: Failed to fetch plugin https://github.com/mlynch/azure-activedirectory-library-for-cordova.git via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.